### PR TITLE
Fix pulling captions from attachment caption field

### DIFF
--- a/includes/acf_photo_gallery.php
+++ b/includes/acf_photo_gallery.php
@@ -13,10 +13,15 @@ function acf_photo_gallery_make_images($attachment_ids, $field, $post_id = null,
 		$fieldname = $field;
 	}
 	$array = array();
+	$use_attachment_caption = apply_filters('acf_photo_gallery_caption_from_attachment', $field);
 	if( count($images) ):
 		foreach($images as $image):
 			$title = $image->post_title;
-			$content = $image->post_content;
+			if ($use_attachment_caption) {
+				$content = wp_get_attachment_caption($image->ID);
+			} else {
+				$content = $image->post_content;
+			}
 			$full_url = wp_get_attachment_url($image->ID);
 			$thumbnail_url = wp_get_attachment_thumb_url($image->ID);
 			$meta_data = wp_get_attachment_metadata($image->ID);

--- a/includes/acf_photo_gallery_edit_save.php
+++ b/includes/acf_photo_gallery_edit_save.php
@@ -19,7 +19,7 @@ function acf_photo_gallery_edit_save(){
 		unset( $request['title'] );
 		unset( $request['caption'] );
 
-		$acf_photo_gallery_editbox_caption_from_attachment = apply_filters( 'acf_photo_gallery_editbox_caption_from_attachment', $request);
+		$acf_photo_gallery_editbox_caption_from_attachment = apply_filters('acf_photo_gallery_caption_from_attachment', $request);
 		if( $acf_photo_gallery_editbox_caption_from_attachment == 1 ){
 			$captionColumn = 'post_excerpt';
 		} else {

--- a/includes/render_field.php
+++ b/includes/render_field.php
@@ -35,7 +35,7 @@
     <div id="acf-photo-gallery-metabox-edit">
         <?php
             if( $value ):
-                $acf_photo_gallery_editbox_caption_from_attachment = apply_filters( 'acf_photo_gallery_editbox_caption_from_attachment', $field);
+                $acf_photo_gallery_editbox_caption_from_attachment = apply_filters('acf_photo_gallery_caption_from_attachment', $field);
                 $acf_photo_gallery_attachments =  $value;
                 $acf_photo_gallery_attachments = explode(',', $acf_photo_gallery_attachments);
                 $args = array( 'post_type' => 'attachment', 'posts_per_page' => -1, 'post__in' => $acf_photo_gallery_attachments );


### PR DESCRIPTION
Made some changes to make the 'acf_photo_gallery_caption_from_attachment' work as expected. 

On a slightly different note, using this filter may not work as expected if it is registered from another plugin rather than in the theme functions.php as suggested in the readme. I see two possible solutions: 

1. Make a note of this in the readme and suggest using priority > 10 for the filter. 
2. Change the default filter in the plugin constructor to use priority < 10. 

Neither of these option are implemented in the pull request, but let me know what you think and I can add one. Personally I prefer the second one. 