### PR TITLE
Remove unused $field variable

### DIFF
--- a/includes/acf_photo_gallery_save.php
+++ b/includes/acf_photo_gallery_save.php
@@ -40,7 +40,6 @@ add_action( 'save_post', 'acf_photo_gallery_save' );
 
 add_action( 'profile_update', 'my_profile_update', 10, 2 );
 function my_profile_update( $user_id, $old_user_data ){
-	$field = $_POST['acf-photo-gallery-field'];
 	$group = $_POST['acf-photo-gallery-groups'];
 	if( is_array($group) && count($group) > 0 ){
 		foreach($group as $item){


### PR DESCRIPTION
Field can throw an undefined variable error, but is currently unused in the function. Would recommend removing.

Fixes #18 