### PR TITLE
Add REST for custom post types, not only for pages

### DIFF
--- a/navz-photo-gallery.php
+++ b/navz-photo-gallery.php
@@ -46,8 +46,8 @@ if( !class_exists('acf_plugin_photo_gallery') ) :
 			add_action( 'admin_enqueue_scripts', array($this, 'acf_photo_gallery_sortable') );			
 			add_action('acf/include_field_types', array($this, 'include_field_types')); // v5
 			add_action('acf/register_fields', array($this, 'include_field_types')); // v4
+			add_action('rest_api_init', array($this, 'rest_api_init'));
 			add_filter( 'acf_photo_gallery_caption_from_attachment', '__return_false' );
-			add_filter("rest_prepare_page", array($this, 'rest_prepare_post'), 10, 3);
 	        add_action('elementor/dynamic_tags/register_tags', array($this, 'register_tags'));
 			add_filter('plugin_row_meta', array($this, 'acf_pgf_donation_link'), 10, 4 );
 		}
@@ -120,6 +120,12 @@ if( !class_exists('acf_plugin_photo_gallery') ) :
 				}
 			}
 			return $data;
+		}
+
+		function rest_api_init() {
+			foreach (get_post_types() as $name) {
+				add_filter("rest_prepare_$name", array($this, 'rest_prepare_post'), 10, 3);
+			}
 		}
 
 	}


### PR DESCRIPTION
Hello! I notice that /wp-json/ isn't showing galleries created using the new ACF UI for custom post types. I solve this on my website by adding a REST filter for each post type. The list of post types is incomplete when the constructor is called, so to avoid hardcode, I delay the addition of filters until the rest_api_init action. Please see if this works for your websites too.